### PR TITLE
Fixed repo link in file header

### DIFF
--- a/lte-m-iot-connectivity-kit/arduino/LteUdpSoracom/LteUdpSoracom.ino
+++ b/lte-m-iot-connectivity-kit/arduino/LteUdpSoracom/LteUdpSoracom.ino
@@ -7,7 +7,7 @@
  * Copyright SORACOM
  * This software is released under the MIT License, and libraries used by these sketches 
  * are subject to their respective licenses.
- * See also: https://github.com/soracom-labs/soracom-spresense-lte-m-iot-connectivity-kit/blob/main/README.md
+ * See also: https://github.com/soracom-labs/sony-spresense/tree/main/lte-m-iot-connectivity-kit/arduino
  */
 
 // Libraries


### PR DESCRIPTION
The repo link pointed to the old archived repo used while developing this code sample.